### PR TITLE
remove useless dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,6 @@
 source 'https://rubygems.org'
 
 gem 'github-markup'
-gem 'redcarpet'
 gem 'wkhtmltopdf-binary'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ GEM
       posix-spawn (~> 0.3.8)
     posix-spawn (0.3.9)
     rake (10.4.2)
-    redcarpet (3.2.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)
@@ -27,6 +26,5 @@ PLATFORMS
 DEPENDENCIES
   github-markup
   rake
-  redcarpet
   rspec
   wkhtmltopdf-binary


### PR DESCRIPTION
as we can see in https://github.com/arturoherrero/biteydown/blob/master/lib/markup.rb, redcarpet is never used, only github-markdown is used for rendering