### PR TITLE
use kramdown instead of redcarpet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
+
 rvm:
-  - 2.0.0
-  - 2.1.5
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
   - ruby-head
+
 script: bundle exec rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'github-markup'
-gem 'redcarpet'
+gem 'kramdown'
 gem 'wkhtmltopdf-binary'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,34 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    diff-lcs (1.2.5)
-    github-markup (1.3.1)
-      posix-spawn (~> 0.3.8)
-    posix-spawn (0.3.9)
-    rake (10.4.2)
-    redcarpet (3.2.2)
-    rspec (3.1.0)
-      rspec-core (~> 3.1.0)
-      rspec-expectations (~> 3.1.0)
-      rspec-mocks (~> 3.1.0)
-    rspec-core (3.1.7)
-      rspec-support (~> 3.1.0)
-    rspec-expectations (3.1.2)
+    diff-lcs (1.3)
+    github-markup (3.0.2)
+    kramdown (1.17.0)
+    rake (12.3.2)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.1.0)
-    rspec-mocks (3.1.3)
-      rspec-support (~> 3.1.0)
-    rspec-support (3.1.2)
-    wkhtmltopdf-binary (0.9.9.3)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    wkhtmltopdf-binary (0.12.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   github-markup
+  kramdown
   rake
-  redcarpet
   rspec
   wkhtmltopdf-binary
+
+BUNDLED WITH
+   2.0.1

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Markdown is a lightweight markup language designed as an easy-to-read, easy-to-w
 
 ![image](cv-css-selectors.png)
 
-CSS works by associating rules with HTML elements. In this case, there are a little group of selectors that can be used: `h1-h6`, `blockquote`, `a`, `li`, `code`, `strong`, `em`, `img`. You cannot use id or class selectors to create rules that apply to elements.
+CSS works by associating rules with HTML elements. In this case, there are a little group of selectors that can be used: `h1-h6`, `blockquote`, `a`, `li`, `code`, `strong`, `em`, `img`. You can use id or class selectors to create rules that apply to elements by using kramdown [block attributes](https://kramdown.gettalong.org/quickref.html#block-attributes) syntax.
 
 
 [Markdown]: http://daringfireball.net/projects/markdown/
+[Kramdown]: https://kramdown.gettalong.org/

--- a/example/curriculum.md
+++ b/example/curriculum.md
@@ -31,30 +31,36 @@ Greach, Codemotion, SoCraTes UK and local user groups.
 
 ## Experience
 
-**Software Engineer** at *[Mastered][12]*. `jun 2015 - present`  
+**Software Engineer** at *[Mastered][12]*. `jun 2015 - present`
+
 > I joined the team as their second developer; we are now a cross-functional
 team of nine people. We are defining and building the product with Ruby on Rails
 working as a RESTful API consumed by AngularJS and an iOS app.
 
-**Software Engineer** at *[AMEE][11]*. `mar 2015 - may 2015`  
+**Software Engineer** at *[AMEE][11]*. `mar 2015 - may 2015`
+
 > I have worked in a data driven environment as full stack web developer.
 
-**Software Developer** at *[Plex][10]*. `jan 2015 - feb 2015`  
+**Software Developer** at *[Plex][10]*. `jan 2015 - feb 2015`
+
 > I worked on improving the website with the Ruby on Rails team.
 
-**Lead Developer** at *[Coinfloor][4]*. `jan 2014 - jan 2015`  
+**Lead Developer** at *[Coinfloor][4]*. `jan 2014 - jan 2015`
+
 > I worked building the first UK Bitcoin exchange. Speed, scalability, security and
 reliability are key features in the development. The system is based in a Ruby
 microservices architecture communicated with RabbitMQ.
 
-**Software Engineer** at *[Cambridge Healthcare][5]*. `may 2013 - dec 2013`  
+**Software Engineer** at *[Cambridge Healthcare][5]*. `may 2013 - dec 2013`
+
 > I worked building a health record, analytics and open API.  
 My main task was to develop and design RESTful web services with Ruby. I crafted
 different web APIs implemented using HTTP and REST principles,
 Entity-Boundary-Interactor architecture, Elasticsearch and Redis for the
 persistence.
 
-**Software Engineer** at *[OSOCO][7]*. `nov 2010 - mar 2013`  
+**Software Engineer** at *[OSOCO][7]*. `nov 2010 - mar 2013`
+
 > I worked as a software developer and technical consultant, with a focus on
 web applications using Groovy and Grails and hosted in Amazon AWS.  
 I developed a social network and training plan manager focused on cycling:
@@ -65,7 +71,8 @@ I developed a social network and training plan manager focused on cycling:
 
 ## Education
 
-**Software Engineering Degree** at *Universidad Politécnica de Madrid*. `jul 2010`  
+**Software Engineering Degree** at *Universidad Politécnica de Madrid*. `jul 2010`
+
 > Highest mark possible on Final Project Degree, awarded 10/10.  
 > Applied for Excellence in Academic Achievement Scholarship 2009/2010, average mark of 8.29/10.
 

--- a/example/curriculum.md
+++ b/example/curriculum.md
@@ -14,6 +14,7 @@ experience working with different dynamic programming languages, especially
 languages. I am highly experienced in web development and complex
 architectures. I love creating elegant software that is easy to read and
 provides immediate and lasting value to its users.
+{: .lead }
 
 I have been involved in several successful projects as a member of a **Scrum
 team**, participating in the analysis, design and development. I am interested

--- a/lib/converter.rb
+++ b/lib/converter.rb
@@ -13,10 +13,11 @@ class Converter
   def create_pdf_file(html)
     create_html_file(html)
 
-    `wkhtmltopdf #{html_path} \
+    `wkhtmltopdf \
       --encoding UTF-8 \
       --page-size Letter \
       --quiet \
+      #{html_path} \
       #{pdf_path}`
 
     File.delete(html_path)

--- a/lib/converter.rb
+++ b/lib/converter.rb
@@ -17,6 +17,7 @@ class Converter
       --encoding UTF-8 \
       --page-size Letter \
       --quiet \
+      --lowquality \
       #{html_path} \
       #{pdf_path}`
 

--- a/lib/markup.rb
+++ b/lib/markup.rb
@@ -2,7 +2,7 @@ require 'github/markup'
 
 class Markup
   def generate_html(markdown_path, css_path)
-    html = GitHub::Markup.render(markdown_path)
+    html = GitHub::Markup.render(markdown_path, File.read(markdown_path))
     add_stylesheet!(html, css_path)
     add_head!(html)
   end

--- a/style/style.css
+++ b/style/style.css
@@ -37,3 +37,8 @@ li {
   margin-bottom: 2px;
   list-style-type: square;
 }
+
+.lead {
+  font-size: 110%;
+  line-height: 1.5;
+}


### PR DESCRIPTION
Hey @arturoherrero 👋

thank you for sharing this litte beauty. 
I've had problems installing the old ruby's and gems due to OpenSSL issues and wanted to contribute these suggestions below. 

So I've updated the dependencies to the latest versions and dropped all ruby binaries that are EOL.
GitHub itself swapped `redcarpet` with `kramdown` for GitHub Pages and I thought it would be nice to have the ability to use custom css (id/class) selectors with kramdown's block attribute syntax. (eg. `{: .my-class #my-id}`) for easier target specific areas.

Hope you like it, feedback is welcome ✌️

###### commits

* setup current stable ruby releases for travis ci
* remove EOL ruby’s
* use kramdown markdown engine
  * https://blog.github.com/2016-05-02-github-pages-drops-support-for-rdiscount-redcarpet-and-redcloth-textile-markup-engines/
* update outdated dependencies
  * run `bundle update`
* update wkhtmltopdf cli cmd
* update github/markup render usage
  * https://github.com/github/markup#usage
* add required `—lowquality` flag on wkhtmltopdf `v0.12.4`
  * wkhtmltopdf/wkhtmltopdf#3241 (comment)
* setup custom css selector for lead paragraph
  * use kramdown block attributes syntax
  * https://kramdown.gettalong.org/quickref.html#block-attributes
* add kramdown block attributes to readme
* fix blockquote rendering using kramdown